### PR TITLE
[ING-666] Arrumar nome do método de resetar a senha no legiti 

### DIFF
--- a/packages/trackers/src/methods/password.methods.js
+++ b/packages/trackers/src/methods/password.methods.js
@@ -38,7 +38,7 @@ function reset(userId) {
     }
 
     try {
-        return legiti('trackPasswordRecovery', userId);
+        return legiti('trackPasswordReset', userId);
 
     } catch (error) {
         return error;


### PR DESCRIPTION
O nome do método do legiti para para resetar a senha estava com o nome errado, a tarefa consistia em apenas arrumar esse nome seguindo a documentação do legiti 

## Related Issues
[ING-666] 

[ING-666]: https://ingresse.atlassian.net/browse/ING-666